### PR TITLE
生图提示词独立文件化，多参数配置文件化与管理员统一

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🎨 AstrBot Plugin ComfyUI Pro
+# AstrBot Plugin ComfyUI Pro
 
 ## 需要特别提到的事：
 本插件并没有提供ui来直接配置工作流的图片尺寸，步数，lora等的选项，这并不是为了增加上手难度，相反，这是为了提供最大的灵活性和兼容性。这个调整可以让插件适配所有（大概）工作流，只要你有，经过简单的几个步骤，你就可以通过本插件调用。
@@ -7,11 +7,11 @@
 ## 介绍
 一个功能强大的 AstrBot 插件，旨在将你本地的 **ComfyUI** 无缝集成到聊天机器人中。
 
-它不仅支持基础的文生图，更创新的引入了 LLM（大语言模型）作为“提示词工程师”，能够将用户的日常对话自动转化为 ComfyUI 可识别的高质量英文 Prompt。同时，它对 ComfyUI 用户极其友好，支持便捷地导入和切换你自己的工作流，并提供了完善的权限控制和敏感词过滤系统。
+它不仅支持基础的文生图，更创新的引入了 LLM（大语言模型）作为"提示词工程师"，能够将用户的日常对话自动转化为 ComfyUI 可识别的高质量英文 Prompt。同时，它对 ComfyUI 用户极其友好，支持便捷地导入和切换你自己的工作流，并提供了完善的权限控制、敏感词过滤、Persona 提示词管理和 Profile 一键配置系统。
 
 导入工作流请务必参考教程。
 
-## 🚀 核心优势：轻松使用你自己的工作流
+## 核心优势：轻松使用你自己的工作流
 
 本插件最大的特点就是让你几乎无缝地使用你在 ComfyUI 中已经搭建好的工作流。只需简单几步，就能将你的创意带入 AstrBot。
 
@@ -21,42 +21,61 @@
 ### 二、找到关键节点 ID
 记下你的工作流中 **输入** 和 **输出** 节点的 ID。开启开发者模式后，ID 会显示在每个节点的标题上方。
 *   **输入节点 (Input ID)**: 通常是接收提示词的 `CLIP Text Encode` 节点。**（必需）**
+*   **负面提示词节点 (Neg Node ID)**: 接收负面提示词的节点。可选，如无则填写任意不存在的 ID。
 *   **输出节点 (Output ID)**: 最终生成图像的 `Save Image` 或 `Preview Image` 节点。**（必选）**
 
 ### 三、放置并配置
 1.  将导出的 `.json` 文件放入插件的 `workflow` 目录中。
-    *   路径为: `data/plugins/astrbot_plugin_comfyui_pro/workflow/`
+    *   路径为: `data/plugin_data/astrbot_plugin_comfyui_pro/workflow/`
 2.  **重载插件**，然后刷新网页，再次**重载插件**，这样才可以看到你刚才放进的workflow。
-3.  进入插件设置，在“工作流设置”中：
+3.  进入插件设置，在"工作流设置"中：
     *   选择你刚刚放入的 `.json` 文件。
     *   填入你记下的 **节点ID**。
 4.  **完成！** 现在你的机器人就可以使用这个专属工作流进行绘画了。
 
 ---
 
-## ✨ 主要功能
+## 主要功能
 
-### 🔌 ComfyUI 深度集成
+### ComfyUI 深度集成
 *   **便捷工作流导入**: 完美支持 ComfyUI 的 API 格式工作流，让你专注于创意。
 *   **多工作流热切换**: 在 AstrBot 后台或通过管理员指令，随时切换不同的模型和风格（如 SDXL、二次元、写实、特定 LoRA 流等）。
 *   **智能参数注入**: 自动将提示词注入到你指定的输入节点，并智能寻找种子节点以实现随机化，避免生成重复图片。
+*   **步数覆盖**: 支持按节点 ID 精确控制步数，适配复杂多面板工作流。
 
-### 🤖 智能 LLM 绘图
-*   **自然语言生图**: 用户只需说“帮我画一个...”，LLM 即自动分析、优化并生成高质量英文提示词，触发绘图，真正实现“开箱即用”。
+### 智能 LLM 绘图
+*   **自然语言生图**: 用户只需说"帮我画一个..."，LLM 即自动分析、优化并生成高质量英文提示词，触发绘图，真正实现"开箱即用"。
 *   **指令生图**: 为高级用户保留了传统的 `/画图` 指令，可直接输入英文 Tag 进行精准控制。
-*   **高度可定制**: 你可以随时在后台修改 System Prompt，定制你的“AI 绘画助手”人设和回复风格。
+*   **高度可定制**: 可通过 Persona 文件管理多套系统提示词，在聊天中动态切换，定制你的"AI 绘画助手"人设和回复风格。
 *   **当前触发格式**: 插件会从 LLM 回复中提取 `<pic prompt="...">` 标签作为绘图提示词，并会自动忽略 `<think> ... </think>` 内容。
 *   **注意事项**：如果你自定义了 System Prompt，请确保需要出图时最终回复里包含合法的 `<pic prompt="英文 tags">`；如果没有这个标签，插件就不会触发绘图。
-  
-### 🛡️ 完善的风控与权限
+
+### Persona 提示词管理 (v2.4)
+*   **文件化管理**: 提示词以 `.txt` 纯文本文件存储在 `persona/` 目录中，便于编辑和版本管理。
+*   **WebUI 切换**: 在插件配置页面的下拉菜单中直接选择 Persona 文件。
+*   **终端切换**: 管理员通过 QQ/终端发送指令切换当前 Persona：
+    *   `/comfy_prompt_ls` — 列出所有 Persona 文件及预览
+    *   `/comfy_prompt_use <序号>` — 切换当前使用的 Persona
+*   **优先级**: Persona 文件 > WebUI 文本框输入（回退项）
+
+### Profile 一键配置 (v2.4)
+*   **一键绑定**: 将工作流文件 + 正/负面提示词节点 ID + 输出节点 ID + Persona 文件绑定为一个 Profile 配置文件。
+*   **WebUI 管理**: 配置页面提供 Profile 文件下拉选择，以及现场保存功能。
+*   **终端指令**:
+    *   `/comfy_profile_ls` — 列出所有 Profile 绑定详情
+    *   `/comfy_profile_use <序号>` — 一键应用 Profile（自动切换工作流+节点ID+Persona）
+    *   `/comfy_profile_save <名称>` — 将当前配置保存为 Profile
+
+### 风控与权限
 *   **分级违禁词过滤**: 内置 `Lite` 和 `Full` 两级敏感词库，支持中英文过滤，可为不同群组设置不同策略。
-*   **白名单与全局锁定**: 可设置仅在白名单群组生效，或一键开启“全局锁定”，仅允许管理员使用。
+*   **白名单与全局锁定**: 可设置仅在白名单群组生效，或一键开启"全局锁定"，仅允许管理员使用。
 *   **锁定命令开关**: 支持 `/comfy_lock on|off|status` 动态切换全局锁定，也可以在配置里关闭这个命令入口。
-*   **管理员特权**: 管理员可配置“无视冷却”、“无视白名单”、“无视敏感词”等超级权限。
+*   **管理员特权**: 管理员可配置"无视冷却"、"无视白名单"、"无视敏感词"等超级权限。
+*   **统一管理员**: 使用 AstrBot 系统管理员列表，无需在插件中重复配置管理员 ID。
 
 ---
 
-## ⚙️ 详细配置说明
+## 详细配置说明
 
 在 AstrBot 仪表盘 -> 插件 -> `astrbot_plugin_comfyui_pro` 中点击设置：
 
@@ -66,16 +85,21 @@
 ### 2. 工作流设置 (Workflow Settings)
 *   `JSON File`: **(核心)** 选择一个你已放入 `workflow` 文件夹的工作流文件。
 *   `Input Node ID`: **(核心)** 你的工作流中，接收正向提示词的节点 ID。
-*   `Output Node ID`: **(核心)** 输出图片的节点 ID 。
+*   `Neg Node ID`: 接收负面提示词的节点 ID（如无，可填任意不存在的 ID）。
+*   `Output Node ID`: **(核心)** 输出图片的节点 ID。
 
-### 3. LLM 设置 (LLM Settings)
-*   `System Prompt`: 在这里编辑给 LLM 的系统提示词，定义它如何响应用户的画图请求。
-    > ⚠️ **CRITICAL**: 插件当前通过正则表达式 `<pic\s+prompt="(.*?)">` 提取绘图提示词。无论你如何修改 System Prompt，**必须**确保最终 LLM 的回复在需要出图时包含合法的 `<pic prompt="...">` 标签，否则插件将无法触发绘图。
-    >
-    > 推荐同时保留 `<think> ... </think>` + `<pic prompt="...">` 的输出顺序，这与插件默认配置和多图分段逻辑保持一致。
+### 3. 配置档案 (Profile Settings) — v2.4 新增
+*   `Profile File`: 选择一个 Profile 配置文件，自动同步切换工作流、节点 ID 和 Persona。留空则使用各自的独立配置。
+*   `Save Profile Name`: 调整好上方各设置后，在此输入档案名称并保存，当前配置将作为 Profile 持久化。
 
-### 4. 访问控制 (Control)
-*   **管理员与白名单**: 设置管理员 QQ 号和允许使用插件的群号。
+### 4. LLM 设置 (LLM Settings)
+*   `Persona File`: 选择 Persona 提示词文件（`persona/` 目录下的 `.txt` 文件）。选择后优先使用文件内容。
+*   `System Prompt`: 当上方 Persona 文件未选择时，使用此文本框内容作为回退提示词。
+    > **CRITICAL**: 插件当前通过正则表达式 `<pic\s+prompt="(.*?)">` 提取绘图提示词。无论你如何修改 System Prompt，**必须**确保最终 LLM 的回复在需要出图时包含合法的 `<pic prompt="...">` 标签，否则插件将无法触发绘图。
+
+### 5. 访问控制 (Control)
+*   **管理员**: 插件使用 AstrBot 系统管理员列表（在 AstrBot WebUI 权限管理中设置），无需重复配置。
+*   **白名单群**: 设置允许使用插件的群号列表。
 *   **冷却时间**: 防止用户刷屏。
 *   **全局锁定**: `lockdown` 为静态总开关，开启后仅管理员可用。
 *   **锁定命令开关**: `lockdown_command_enabled` 控制是否允许管理员使用 `/comfy_lock on|off|status` 动态切换锁定状态。
@@ -83,18 +107,18 @@
 
 ---
 
-## 📖 指令与用法
+## 指令与用法
 
 ### 方式一：自然语言对话 (推荐)
 直接与机器人对话，让它帮你画。
-*   **你**: “帮我画一只猫，赛博朋克风格，在下雨的东京街头”
+*   **你**: "帮我画一只猫，赛博朋克风格，在下雨的东京街头"
 *   **机器人**: (分析需求 -> 生成 Prompt -> 调用 ComfyUI -> 发送图片)
 
 ![llm演示](https://raw.githubusercontent.com/lumingya/astrbot_plugin_comfyui_pro/main/assets/llm.png)
 
 ### 方式二：直接指令
 *   `/画图 <提示词>`: 以合并转发的方式发送图片。
-*   
+
 ![指令演示](https://raw.githubusercontent.com/lumingya/astrbot_plugin_comfyui_pro/main/assets/draw.png)
 
 *   `/画图no <提示词>`: 直接发送图片，更简洁。
@@ -102,15 +126,34 @@
 ![指令演示](https://raw.githubusercontent.com/lumingya/astrbot_plugin_comfyui_pro/main/assets/drawno.png)
 
 ### 方式三：管理指令 (仅管理员)
+**工作流管理：**
 *   `/comfy_ls`: 列出所有可用的工作流，并显示序号。
 *   `/comfy_use <序号> [input_id] [output_id]`: 通过序号快速切换工作流，该方法不需要重载插件。
+*   `/comfy_save <文件名>`: 通过分享 JSON 文件导入新的工作流。
+
+**Persona 管理 (v2.4)：**
+*   `/comfy_prompt_ls`: 列出所有 Persona 文件及首行预览。
+*   `/comfy_prompt_use <序号>`: 切换当前使用的 Persona 提示词。
+
+**Profile 管理 (v2.4)：**
+*   `/comfy_profile_ls`: 列出所有 Profile 配置及其绑定的工作流、节点 ID、Persona。
+*   `/comfy_profile_use <序号>`: 一键应用 Profile（自动切换工作流 + 节点 ID + Persona）。
+*   `/comfy_profile_save <名称>`: 将当前配置保存为 Profile 文件。
+
+**步数覆盖：**
+*   `/comfy_add <节点ID> <步数>`: 按节点 ID 设置步数覆盖。
+*   `/comfy_add <节点ID> off`: 取消单个步数覆盖。
+*   `/comfy_add list`: 查看当前工作流的覆盖配置。
+*   `/comfy_add clear`: 清空当前工作流的所有步数覆盖。
+
+**其他：**
 *   `/comfy_lock on|off|status`: 动态查看或切换全局锁定状态。
 *   `/违禁级别 <none/lite/full>`: 调整当前群的敏感词拦截等级。
-*   `/comfy帮助`: 查看所有可用指令。
+*   `/comfy帮助`: 查看所有可用指令及当前状态。
 
 ---
 
-## ❓ 常见问题 (FAQ)
+## 常见问题 (FAQ)
 
 **Q: 为什么 LLM 回复了 `<pic prompt="...">`，但没有出图？**
 A: 99% 的可能是配置问题。请检查：
@@ -120,177 +163,86 @@ A: 99% 的可能是配置问题。请检查：
     4.  后台日志中是否有报错信息？
 
 **Q: 我新添加的 `.json` 文件在插件设置的下拉菜单里看不到？**
-A: 这是 AstrBot 的缓存机制导致。请在后台 **“重载插件”**，然后 **“刷新你的浏览器网页 (F5)”**，然后再次**“重载插件”**，新的选项就会出现。
+A: 这是 AstrBot 的缓存机制导致。请在后台 **"重载插件"**，然后 **"刷新你的浏览器网页 (F5)"**，然后再次**"重载插件"**，新的选项就会出现。
 
 **Q: 生成的图片总是一样的？**
-A: 插件会自动寻找并修改名为 `seed` 或 `noise_seed` 的参数。如果你的工作流使用了非常规的自定义种子节点，插件可能无法识别。请尝试在设置中手动指定 `Seed Node ID`。
+A: 插件会自动寻找并修改名为 `seed` 或 `noise_seed` 的参数。如果你的工作流使用了非常规的自定义种子节点，插件可能无法识别。
 
-# 📋 Version 2.0.0 更新日志
-✨ 新增：步数覆盖功能（按节点ID精确控制）
+---
+
+## Version 2.4 更新日志
+
+### 新增：Persona 提示词管理系统
+*   提示词以 `.txt` 纯文本文件存储在 `persona/` 目录中
+*   WebUI 配置页面提供 Persona 文件下拉选择
+*   终端指令 `/comfy_prompt_ls` 和 `/comfy_prompt_use` 支持动态切换
+*   优先级链：终端命令 > WebUI 下拉 > 文本框回退
+
+### 新增：Profile 一键配置系统
+*   将工作流 + 节点 ID + Persona 绑定为 Profile 配置文件
+*   WebUI 配置页面提供 Profile 文件选择与现场保存
+*   终端指令 `/comfy_profile_ls`、`/comfy_profile_use`、`/comfy_profile_save` 支持管理
+
+### 修改：管理员系统统一
+*   移除插件自定义管理员白名单 (`admin_ids`)
+*   改用 AstrBot 框架内置管理系统 (`event.is_admin()`)
+*   兼容新版 AstrBot 的多用户配置文件 (`abconf_*.json`)
+
+---
+
+## Version 2.0 更新日志
+
+### 新增：步数覆盖功能（按节点ID精确控制）
 针对复杂工作流（如包含多个 ParameterControlPanel 的场景），现在可以按节点ID单独设置步数，彻底解决了"ComfyUI 前端修改参数会影响插件生成"的问题。
 
+新增指令：`/comfy_add`
 
-新增指令：/comfy_add（该指令正常无需使用，目前仅针对 ParameterControl节点）
-
-text
-
+```
 /comfy_add <节点ID> <步数>           单个设置
 /comfy_add <ID1> <步数1> <ID2> <步数2>   批量设置
 /comfy_add <节点ID> off              取消单个覆盖
 /comfy_add list                      查看当前工作流的覆盖配置
 /comfy_add clear                     清空当前工作流的所有覆盖
-使用示例：
+```
 
-text
-
-/comfy_add 3839 20              # 底图部分设为20步
-/comfy_add 3839 20 4521 50      # 同时设置底图20步、放大50步
-/comfy_add list                 # 查看当前配置
 特性：
+*   覆盖配置按工作流文件独立存储（工作流名.steps.json）
+*   支持一个工作流配置多个不同节点的步数
+*   切换工作流时自动加载对应的覆盖配置
+*   完全脱离 ComfyUI 前端状态，插件生成参数独立可控
 
-覆盖配置按工作流文件独立存储（工作流名.steps.json）
-支持一个工作流配置多个不同节点的步数
-切换工作流时自动加载对应的覆盖配置
-完全脱离 ComfyUI 前端状态，插件生成参数独立可控
-🔧 优化
-📂 工作流管理优化
-/comfy_ls 现在会显示每个工作流的覆盖配置数量
-/comfy_use 切换工作流时自动排除配置文件（.steps.json）
-工作流列表更新时自动过滤配置文件
-🛡️ 稳定性提升
-优化 ParameterBreak 节点检测逻辑，自动识别无需硬编码节点ID
-增加覆盖生效日志，方便调试确认
+### 优化
+*   `/comfy_ls` 现在会显示每个工作流的覆盖配置数量
+*   `/comfy_use` 切换工作流时自动排除配置文件（.steps.json）
+*   优化 ParameterBreak 节点检测逻辑，自动识别无需硬编码节点ID
 
-从 v2.0 开始，插件采用 AstrBot 规范的数据持久化方案。你的工作流、生成的图片、自定义敏感词等数据将存储在独立的数据目录中，**更新插件不会覆盖这些文件**。
-
-### 📂 新的目录结构
+### 新的目录结构
 
 ```
-data/plugin_data/astrbot_plugin_comfyui_pro/   # ✅ 持久化目录（更新不丢失）
+data/plugin_data/astrbot_plugin_comfyui_pro/   # 持久化目录（更新不丢失）
 ├── workflow/                                   # 你的工作流文件
-│   ├── workflow_api.json                       # 首次安装时自动复制
-│   └── my_custom_workflow.json                 # 你自己添加的
-├── output/                                     # 生成的图片历史
+│   ├── workflow_api.json
+│   └── my_custom_workflow.json
+├── persona/                                    # Persona 提示词文件 (v2.4)
+│   └── default.txt
+├── profiles/                                   # Profile 配置文件 (v2.4)
+│   └── default.json
+├── output/                                     # 生成的图片
 │   └── *.png
-└── sensitive_words.json                        # 敏感词配置（可自定义）
-
-plugins/astrbot_plugin_comfyui_pro/            # ⚠️ 插件目录（更新会覆盖）
-├── main.py
-├── comfyui_api.py
-└── ...
+└── sensitive_words.json                        # 敏感词配置
 ```
-
-### 🔄 迁移指南（从 v1.x 升级）
-
-如果你之前已经在使用本插件：
-
-1. **备份你的工作流文件**
-   - 复制 `plugins/astrbot_plugin_comfyui_pro/workflow/` 下的所有 `.json` 文件
-
-2. **更新插件**
-
-3. **恢复工作流**
-   - 将备份的文件放入新目录：`data/plugin_data/astrbot_plugin_comfyui_pro/workflow/`
-
-4. **重载插件**（两次重载 + 刷新浏览器，老规矩）
-
-> 💡 **提示**：你在 AstrBot 后台填写的配置（管理员ID、白名单群等）由框架管理，**不会丢失**，无需额外操作。
-
----
-
-## ✨ 新增功能
-
-### 🚀 首次安装自动初始化
-- 首次安装插件时，会自动将插件自带的默认工作流和敏感词文件复制到数据目录
-- 无需手动配置即可开始使用
-
-### 📝 全新的日志与提示系统
-所有提示信息现在都会告诉你**具体原因**，不再是简单的"禁止输入"：
-
-| 场景 | v1.x | v2.0 |
-|------|------|------|
-| 群不在白名单 | `禁止输入。` | `🚫 本群(123456)不在白名单中` |
-| 全局锁定 | `全局锁定。` | `🔒 全局锁定中，仅管理员可用` |
-| 冷却中 | `请求太频繁...` | `⏱️ 冷却中，请在 30 秒后重试` |
-| 权限不足 | `权限不足。` | `🚫 权限不足，仅管理员可查看工作流列表` |
-| 敏感词拦截 | `检测到敏感词：xxx` | `🚫 检测到敏感词：xxx、yyy，无法生成图片` |
-
-### 📊 更清晰的启动日志
-```
-[ComfyUI] 📂 数据目录: .../plugin_data/astrbot_plugin_comfyui_pro
-[ComfyUI] 📋 已复制 6 个默认工作流
-[ComfyUI] 🔄 工作流列表已更新: 13 个可用
-[ComfyUI] 👤 管理员: 2 个 | 🏠 白名单群: 3 个
-[ComfyUI] 🔒 敏感词库已加载: 1234 个词条
-[ComfyUI] ✅ ComfyUI API 初始化成功
-[ComfyUI] 🎨 插件初始化完成，LLM 工具已激活
-```
-
----
-
-## 🔧 优化与修复
-
-### 代码优化
-- 统一使用 `pathlib.Path` 处理路径，提高跨平台兼容性
-- 重构权限检查逻辑，代码更清晰，维护更方便
-- 优化 ComfyUI API 初始化，支持传入数据目录参数
-
-### 帮助命令优化
-- `/comfy帮助` 现在会显示更多状态信息（当前位置、违禁级别、冷却时间）
-- 管理员可以看到数据目录路径，方便管理
-- `/comfy_ls` 现在会高亮显示当前正在使用的工作流
-
-### 其他改进
-- 敏感词提示最多显示 5 个，避免消息过长
-- 生成图片时会记录日志，方便追踪问题
-- 工作流切换时的提示更加详细
-
----
-
-## ⚠️ 注意事项
-
-### 关于工作流存放位置
-**从 v2.0 开始，工作流文件应该放在：**
-```
-data\plugin_data\astrbot_plugin_comfyui_pro\workflow
-```
-而**不是**之前的：
-```
-data\plugins\astrbot_plugin_comfyui_pro/workflow/
-```
-
-插件目录下的 `workflow` 文件夹现在仅用于存放**默认模板**，供首次安装时复制使用。
-
-敏感词配置和图片存储同样在：
-```
-data\plugin_data\astrbot_plugin_comfyui_pro
-```
-### 关于配置保留
-以下配置由 AstrBot 框架管理，**更新插件不会丢失**：
-- ✅ ComfyUI 服务地址
-- ✅ 工作流节点 ID 配置
-- ✅ 管理员 ID 列表
-- ✅ 白名单群列表
-- ✅ 冷却时间、违禁级别等所有设置
 
 ---
 
 ## Hardening Notes
 
-This plugin now applies a few compatibility-preserving safety defaults:
-
-- `server_address` values are normalized automatically:
-  - surrounding whitespace is trimmed
-  - missing scheme defaults to `http://`
-  - trailing `/` is removed
-- HTTP requests now use sane default timeouts instead of waiting forever
-- transient API failures (for example `429`, `502`, `503`, `504`) are retried with backoff
-- existing configs remain valid; if you already provide a full URL, behavior is unchanged
+*   `server_address` 自动规范化（去空格、补协议、去末尾 `/`）
+*   HTTP 请求有合理的超时设置和重试机制（429/502/503/504 自动退避重试）
+*   插件更新不会覆盖 `data/plugin_data/` 下的持久化数据
 
 ### Recommended configuration hygiene
 
-- Prefer a direct ComfyUI URL such as `http://127.0.0.1:8188`
-- Avoid trailing slashes in `server_address`
-- If your ComfyUI runs behind a reverse proxy, make sure long-running requests are allowed enough upstream timeout budget
-- Treat workflow execution as asynchronous and expect queue wait time under load
-
+*   Prefer a direct ComfyUI URL such as `http://127.0.0.1:8188`
+*   Avoid trailing slashes in `server_address`
+*   If your ComfyUI runs behind a reverse proxy, make sure long-running requests are allowed enough upstream timeout budget
+*   Treat workflow execution as asynchronous and expect queue wait time under load

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -61,6 +61,26 @@
       }
     }
   },
+  "profile_settings": {
+    "description": "配置档案（一键切换工作流+节点ID+Persona 绑定）",
+    "type": "object",
+    "items": {
+      "profile_file": {
+        "description": "配置档案文件（自动扫描 profiles 目录）",
+        "type": "string",
+        "default": "",
+        "hint": "选择一个 Profile 配置文件，将自动同步切换工作流、正/负面提示词节点ID、输出节点ID 和 Persona。留空则分别使用各自的独立配置。",
+        "options": [],
+        "enum": []
+      },
+      "save_profile_name": {
+        "description": "保存当前配置为档案",
+        "type": "string",
+        "default": "",
+        "hint": "调整好上方工作流设置、Persona 文件等后，在此输入档案名称（无需 .json 后缀）并点击页面底部保存。重载插件后当前配置将保存为 Profile 文件，此字段自动清空。"
+      }
+    }
+  },
   "llm_settings": {
     "description": "大语言模型(LLM)相关配置",
     "type": "object",
@@ -79,10 +99,18 @@
         "default": false,
         "hint": "开启后每次绘图的英文提示词不会累积在历史记录里，可显著减少上下文长度"
       },
+      "persona_file": {
+        "description": "Persona 提示词文件（自动扫描 persona 目录）",
+        "type": "string",
+        "default": "",
+        "hint": "选择一个 Persona 文件作为 LLM 绘图系统提示词。选择后优先使用文件内容，忽略下方文本框。留空则回退到下方文本框。",
+        "options": [],
+        "enum": []
+      },
       "system_prompt": {
-        "description": "ComfyUI 绘图工具的系统提示词",
+        "description": "ComfyUI 绘图工具的系统提示词（回退项）",
         "type": "text",
-        "hint": "定义 LLM 应该如何处理用户的画图请求，以及输出格式。必须包含 <pic prompt=\"...\"> 标记格式说明。",
+        "hint": "当上方 Persona 文件未选择或文件不可用时，使用此文本框内容。正确定义 LLM 的绘图输出格式，必须包含 <pic prompt=\"...\"> 标记格式说明。",
         "default": "【角色扮演动态插图系统｜ComfyUI 分镜导演版】\n\n你正在参与角色扮演文本生成，同时兼任“动态插图分镜导演”。\n你的职责不是把正文逐句翻译成 prompt，而是从当前剧情里挑出“最值得定格的一瞬”，生成一条最稳定、最好看、最适合本地 ComfyUI 出图的 Stable Diffusion / Danbooru 风格英文 tags。\n\n你的最高目标只有 4 个：\n1. 单图单任务：一张图只服务一个视觉核心，不贪多。\n2. 稳定优先：宁可少画一点，也要镜头准、动作稳、脸不崩。\n3. 镜头优先：先决定拍什么、从哪拍，再写 tags。\n4. 角色连续：同一角色在同一段剧情中的外貌、服装、气质要保持一致，除非剧情明确改变。\n\n--------------------------------------------------\n【一、输出格式强约束｜违反即视为错误】\n--------------------------------------------------\n\n1. 唯一允许的图片触发标签：\n`<pic prompt=\"...\">`\n\n系统检测到该标签后，会自动调用绘图接口并替换为图像预览。\n\n\n2. 每次插图时，必须严格按以下顺序输出：\n先输出：\n`<think> ... </think>`\n然后紧跟且只紧跟一个：\n`<pic prompt=\"...\">`\n\n完成后再继续正文叙述。\n\n3. 若当前段落不值得插图：\n不要输出 `<think>`，也不要输出 `<pic>`，直接继续正文。\n\n4. `<pic>` 标签内部规则：\n- 只能有 `prompt` 一个属性\n- 内容必须是 Stable Diffusion / Danbooru 风格英文 tags\n- 只能使用英文单词或短语，半角逗号分隔\n- 允许使用小括号与权重，例如 `(profile view:1.2)`\n- 禁止自然语言长句\n- 禁止换行\n- 禁止非英语字符\n- 禁止在 `<pic>` 外输出“图片说明文字”\n\n5. `<render>` 协同规则：\n`<think>` 与 `<pic>` 可以直接写在 `<render template=\"novel\"> ... </render>` 内部，不必拆块。\n正文与插图都保持在同一个 `<render>` 块中。\n\n6.系统会自动清除历史上下文中的`<pic prompt=\"...\">`和`<think> ... </think>`标签，因此即便上下文中没有画图的记录，也不要以为不需要画图\n\n--------------------------------------------------\n【二、你的真正职责｜先当导演，再当写 tag 的人】\n--------------------------------------------------\n\n插图不是“把刚才那段话画出来”，而是：\n从当前剧情里找出最值得看的一个瞬间，\n选一个最合理的镜头，\n删掉所有会让画面变差的次要信息，\n然后把导演结论转成高收敛英文 tags。\n\n永远记住：\n- 不是信息越多越好，而是“第一眼就读得懂”最好\n- 不是词越花越好，而是“镜头和动作越明确”越好\n- 不是越像 C 站堆词越好，而是越像一个真正会拍画面的导演越好\n\n--------------------------------------------------\n【三、何时应该插图】\n--------------------------------------------------\n\n只有当以下任一条件成立时，才值得插图：\n\n1. 角色首次强势登场\n2. 情绪明显到达峰值\n3. 出现非常适合定格的动作瞬间\n4. 角色关系发生明显变化（靠近、对视、压制、保护、分离）\n5. 进入一个视觉价值很高的新场景\n6. 出现强烈的氛围画面（雨夜、窗边、天台、废墟、舞台等）\n7. 当前画面能显著增强代入感或观赏性\n\n以下情况通常不插图：\n- 纯说明\n- 过渡段\n- 普通对话推进\n- 没有清晰视觉核心的铺垫段\n- 信息很多但不适合定格的段落\n\n--------------------------------------------------\n【四、单图单任务｜先判定这张图的任务类型】\n--------------------------------------------------\n\n每次插图前，你必须先从以下任务类型中只选 1 个：\n\n1. 情绪图\n核心是表情、眼神、心理张力、氛围。\n默认镜头优先：\n`close up` / `portrait` / `upper body`\n`eye level`\n`three-quarter view` 或 `profile view`\n\n2. 动作图\n核心是动作几何、肢体张力、方向感、接触点。\n默认镜头优先：\n`upper body` 或 `cowboy shot`\n`from side` / `profile view` / `three-quarter view`\n`eye level` 或 `low angle`\n\n3. 登场图\n核心是角色魅力、身份感、服装、气场。\n默认镜头优先：\n`upper body` / `cowboy shot`\n`eye level` 或 `low angle`\n`centered`\n\n4. 关系图\n核心是两人之间的距离、对视、接触、支配感、保护感、暧昧感。\n默认镜头优先：\n`two shot`\n`upper body`\n`facing each other` / `side by side` / `over shoulder`\n\n5. 场景建立图\n核心是地点、时间、空间、氛围。\n默认镜头优先：\n`wide shot` / `establishing shot`\n人物降为构图元素，不强调面部与复杂动作。\n\n6. 魅力图\n核心是身体线条、姿态美感、观看体验、角色魅力。\n默认镜头优先：\n`three-quarter view` / `from side`\n`sitting` / `leaning` / `reclining` / `standing`\n`upper body` / `cowboy shot`\n\n7. 高光转折图\n核心是“这一幕最该被记住的瞬间”。\n优先保留最醒目的瞬间信息，舍弃冗余内容。\n\n--------------------------------------------------\n\n你可能会受到一系列参考提示词，当场景贴合时，主动复用参考提示词，那效果会比自己写更好。\n但需要注意场合，R18类型的提示词只有场景明确符合时才能主动生成。\n注意：\n1. 放弃“说人话”，拥抱“打标签” (Tagging > Sentences)\n不要给 AI 写小作文。不要写 A is doing B with C，而是拆解成独立的元素：\n\n❌ 错误：A girl is sitting on a boy's lap and a man's hand is touching her thigh.\n\n✅ 正确：1girl, 1boy, sitting on lap, (male hand touching female thigh:1.2).\n\n2. 肢体动作必须符合“几何逻辑”\nAI 没有三维骨骼概念，它是在二维平面上拼贴像素。给的动作越多，越容易翻车。\n\n如果你的核心是“温馨地坐在怀里”，就用 sitting on lap, arms around neck。\n\n如果你的核心是“腿搭在肩膀上”，那就不要写 sitting on lap，改为 mating press（非全年龄常见标签）或 lying on back, legs on shoulders。动作指令切忌“既要又要”。\n\n3. 镜头语言与画面内容要匹配\n如果你想要一个特写 (Close-up)，就不要去详细描述背景或角色的全身动作。\n\n画全身/半身： 描述姿势 (sitting on lap) + 动作 (arms around neck)。\n\n画特写： close-up, focus on thighs, (male hand touching female thigh:1.3), skindentation。把无关的全身动作（如 sitting on lap）删掉，让 AI 专心画腿和手。\n\n4. 精准使用高频“术语词”\n很多效果是不需要用长篇大论去描述的，一个专有标签就能搞定：\n\n表现肉感/勒肉：用 skindentation，而不是 smooth skin, shaping meat。\n\n表现视角：用 cowboy shot (七分身), from below (仰视), pov (第一人称视角)。\n\n这是例子：\n\n这是好的\n\n(white thighhighs:1.2), lace garter, (skindentation:1.2), 1girl，very long black hair,red eyes,1boy,sitting on lap, arms around neck, (touching thigh:1.1), trembling hands, (shaping thight:1.2),underwear,see through,foot foucus,white skirt,closed legs\n\n这是差的\n\nclose-up, focus on thigh, (white thighhighs:1.2), lace garter, (skindentation:1.3), 1girl sitting on 1boy's lap, leg on shoulder, (man's hand touching thigh:1.1), trembling hands, smooth skin, masterpiece, soft lighting, (shaping thigh meat:1.2), high quality, detailed skin texture"
       }
     }
@@ -95,11 +123,6 @@
         "description": "用户命令冷却时间（秒）",
         "type": "int",
         "default": 35
-      },
-      "admin_ids": {
-        "description": "管理员 QQ 号（列表）",
-        "type": "list",
-        "default": []
       },
       "whitelist_group_ids": {
         "description": "允许使用的群（白名单）",

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from astrbot.api.event import filter, AstrMessageEvent, MessageEventResult
 from astrbot.api.star import Context, Star, register
 from astrbot.api.message_components import *
-from astrbot.api import llm_tool, logger
+from astrbot.api import llm_tool, logger, AstrBotConfig
 from astrbot.api.provider import LLMResponse
 from astrbot.core.message.message_event_result import MessageChain
 # 尝试导入 StarTools（兼容不同版本）
@@ -30,11 +30,11 @@ class _ComfyImageMarker:
         self.index = index
 
 @register(
-    "astrbot_plugin_comfyui_pro",  
-    "lumingya",                    
-    "ComfyUI Pro 连接器",           
-    "1.2.0",
-    "https://github.com/lumingya/astrbot_plugin_comfyui_pro" 
+    "astrbot_plugin_comfyui_pro",
+    "lumingya",
+    "ComfyUI Pro 连接器",
+    "2.4.0",
+    "https://github.com/lumingya/astrbot_plugin_comfyui_pro"
 )
 class ComfyUIPlugin(Star):
     def __init__(self, context: Context, config: dict):
@@ -51,6 +51,8 @@ class ComfyUIPlugin(Star):
         # ====== 3. 设置路径变量 ======
         self.workflow_dir = self.data_dir / "workflow"
         self.output_dir = self.data_dir / "output"
+        self.persona_dir = self.data_dir / "persona"
+        self.profiles_dir = self.data_dir / "profiles"
         self.sensitive_words_path = self.data_dir / "sensitive_words.json"
         
         # ====== 4. 更新 UI 配置 ======
@@ -60,7 +62,6 @@ class ComfyUIPlugin(Star):
         control_conf = config.get("control", {})
         self.cooldown_seconds = control_conf.get("cooldown_seconds", 60)
         self.user_cooldowns = {}
-        self.admin_user_ids = set(map(str, control_conf.get("admin_ids", [])))
         self.lockdown = bool(control_conf.get("lockdown", False))
         self.lockdown_command_enabled = bool(control_conf.get("lockdown_command_enabled", True))
         self.whitelist_group_ids = set(map(str, control_conf.get("whitelist_group_ids", [])))
@@ -92,9 +93,8 @@ class ComfyUIPlugin(Star):
         self.admin_bypass_sensitive = bypass.get("sensitive_words", True)
 
         # 日志：显示管理员和白名单配置
-        admin_count = len(self.admin_user_ids)
         group_count = len(self.whitelist_group_ids)
-        logger.info(f"[ComfyUI] 👤 超级管理员: {admin_count} 个 | 🏠 白名单群: {group_count} 个")
+        logger.info(f"[ComfyUI] 👤 管理员: 使用 AstrBot 系统管理员 | 🏠 白名单群: {group_count} 个")
         if self.lockdown:
             logger.warning("[ComfyUI]⚠️ 绘图功能全局锁定已启用，仅超级管理员可用")
         logger.info(f"[ComfyUI] 🔐 锁定命令开关: {'开启' if self.lockdown_command_enabled else '关闭'}")
@@ -112,6 +112,27 @@ class ComfyUIPlugin(Star):
         except Exception:
             self.lexicon = {"legacy_lite": [], "full": []}
 
+        # ====== 加载当前 persona 选择（持久化） ======
+        self._persona_state_file = self.data_dir / ".current_persona.txt"
+        self.current_persona = None
+        if self._persona_state_file.exists():
+            try:
+                self.current_persona = self._persona_state_file.read_text(encoding="utf-8").strip()
+                logger.info(f"[ComfyUI] 👤 当前 Persona (持久化): {self.current_persona}")
+            except Exception:
+                self.current_persona = None
+
+        # 如果持久化记录不存在，回退到 WebUI 配置中的 persona_file
+        if not self.current_persona:
+            config_persona = config.get("llm_settings", {}).get("persona_file", "").strip()
+            if config_persona:
+                persona_path = self.persona_dir / config_persona
+                if persona_path.exists():
+                    self.current_persona = config_persona
+                    logger.info(f"[ComfyUI] 👤 当前 Persona (配置): {self.current_persona}")
+                else:
+                    logger.warning(f"[ComfyUI] ⚠️ 配置的 Persona 文件不存在: {config_persona}")
+
         self._policy_patterns = {}
         self._build_policy_patterns()
         
@@ -125,6 +146,35 @@ class ComfyUIPlugin(Star):
         except Exception as e:
             logger.error(f"[ComfyUI] ❌ ComfyUI API 初始化失败: {e}")
             logger.error(traceback.format_exc())
+
+        # ====== 加载当前 profile 选择（持久化） ======
+        self._profile_state_file = self.data_dir / ".current_profile.txt"
+        self.current_profile = None
+        if self._profile_state_file.exists():
+            try:
+                self.current_profile = self._profile_state_file.read_text(encoding="utf-8").strip()
+                logger.info(f"[ComfyUI] 📋 当前 Profile (持久化): {self.current_profile}")
+                self._apply_current_profile()
+            except Exception as e:
+                logger.warning(f"[ComfyUI] 应用持久化 profile 失败: {e}")
+                self.current_profile = None
+
+        # 如果持久化记录不存在，回退到 WebUI 配置中的 profile_file
+        if not self.current_profile:
+            config_profile = config.get("profile_settings", {}).get("profile_file", "").strip()
+            if config_profile:
+                profile_path = self.profiles_dir / config_profile
+                if profile_path.exists():
+                    self.current_profile = config_profile
+                    logger.info(f"[ComfyUI] 📋 当前 Profile (配置): {self.current_profile}")
+                    self._apply_current_profile()
+                else:
+                    logger.warning(f"[ComfyUI] ⚠️ 配置的 Profile 文件不存在: {config_profile}")
+
+        # ====== 检测 WebUI 保存请求 ======
+        save_name = config.get("profile_settings", {}).get("save_profile_name", "").strip()
+        if save_name:
+            self._save_profile_from_config(save_name)
 
     # ====== 获取持久化目录 ======
     def _get_persistent_dir(self) -> Path:
@@ -188,47 +238,102 @@ class ComfyUIPlugin(Star):
             except Exception as e:
                 logger.error(f"[ComfyUI] 复制敏感词文件失败: {e}")
 
+        # 复制默认 persona
+        persona_dir = self.data_dir / "persona"
+        persona_dir.mkdir(exist_ok=True)
+        plugin_persona_dir = PLUGIN_DIR / "persona"
+        persona_copied = 0
+        if plugin_persona_dir.exists():
+            for src_file in plugin_persona_dir.glob("*.txt"):
+                dst_file = persona_dir / src_file.name
+                if not dst_file.exists():
+                    try:
+                        shutil.copy2(src_file, dst_file)
+                        persona_copied += 1
+                    except Exception as e:
+                        logger.error(f"[ComfyUI] 复制 persona 失败 {src_file.name}: {e}")
+        if persona_copied > 0:
+            logger.info(f"[ComfyUI] 📋 已复制 {persona_copied} 个默认 Persona")
+
+        # 复制默认 profiles
+        profiles_dir = self.data_dir / "profiles"
+        profiles_dir.mkdir(exist_ok=True)
+        plugin_profiles_dir = PLUGIN_DIR / "profiles"
+        profiles_copied = 0
+        if plugin_profiles_dir.exists():
+            for src_file in plugin_profiles_dir.glob("*.json"):
+                dst_file = profiles_dir / src_file.name
+                if not dst_file.exists():
+                    try:
+                        shutil.copy2(src_file, dst_file)
+                        profiles_copied += 1
+                    except Exception as e:
+                        logger.error(f"[ComfyUI] 复制 profile 失败 {src_file.name}: {e}")
+        if profiles_copied > 0:
+            logger.info(f"[ComfyUI] 📋 已复制 {profiles_copied} 个默认 Profile")
+
     # ====== 更新 Schema ======
     def _auto_update_schema(self):
-        """扫描持久化目录的工作流，更新 UI 下拉列表"""
+        """扫描持久化目录的工作流和 persona，更新 UI 下拉列表"""
         try:
             schema_path = PLUGIN_DIR / '_conf_schema.json'
             workflow_dir = self.data_dir / 'workflow'
 
-            if not workflow_dir.exists():
-                return
-
-            # 排除 .steps.json 文件
-            files = sorted([
-                f.name for f in workflow_dir.glob("*.json")
-                if not f.name.endswith(".steps.json")
-            ])
-        
-            if not files:
-                files = ["workflow_api.json"]
-
             with open(schema_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
 
-            target = data['workflow_settings']['items']['json_file']
-            target['options'] = files
-            target['enum'] = files
-        
-            with open(schema_path, 'w', encoding='utf-8') as f:
-                json.dump(data, f, indent=2, ensure_ascii=False)
-        
-            logger.info(f"[ComfyUI] 🔄 工作流列表已更新: {len(files)} 个可用")
+            modified = False
+
+            # === 工作流列表 ===
+            if workflow_dir.exists():
+                files = sorted([
+                    f.name for f in workflow_dir.glob("*.json")
+                    if not f.name.endswith(".steps.json")
+                ])
+                if not files:
+                    files = ["workflow_api.json"]
+
+                target = data['workflow_settings']['items']['json_file']
+                target['options'] = files
+                target['enum'] = files
+                modified = True
+                logger.info(f"[ComfyUI] 🔄 工作流列表已更新: {len(files)} 个可用")
+
+            # === Persona 列表 ===
+            persona_dir = self.data_dir / 'persona'
+            if persona_dir.exists():
+                persona_files = sorted([f.name for f in persona_dir.glob("*.txt")])
+                target = data['llm_settings']['items'].get('persona_file')
+                if target:
+                    target['options'] = persona_files
+                    target['enum'] = persona_files
+                    modified = True
+                    logger.info(f"[ComfyUI] 🔄 Persona 列表已更新: {len(persona_files)} 个可用")
+
+            # === Profile 列表 ===
+            profiles_dir = self.data_dir / 'profiles'
+            if profiles_dir.exists():
+                profile_files = sorted([f.name for f in profiles_dir.glob("*.json")])
+                target = data['profile_settings']['items'].get('profile_file')
+                if target:
+                    target['options'] = profile_files
+                    target['enum'] = profile_files
+                    modified = True
+                    logger.info(f"[ComfyUI] 🔄 Profile 列表已更新: {len(profile_files)} 个可用")
+
+            if modified:
+                with open(schema_path, 'w', encoding='utf-8') as f:
+                    json.dump(data, f, indent=2, ensure_ascii=False)
 
         except Exception as e:
-            logger.error(f"[ComfyUI] 更新工作流列表失败: {e}")
+            logger.error(f"[ComfyUI] 更新 UI 列表失败: {e}")
 
     # ====== 权限检查（返回原因）======
     def _check_access(self, event: AstrMessageEvent) -> tuple:
         """
         统一的权限检查，返回 (是否通过, 拒绝原因)
         """
-        user_id = str(event.get_sender_id())
-        is_admin = user_id in self.admin_user_ids
+        is_admin = self._is_admin(event)
         
         # 1. 全局锁定检查
         if self.lockdown and not is_admin:
@@ -255,7 +360,7 @@ class ComfyUIPlugin(Star):
         冷却检查，返回 (是否通过, 剩余秒数或0)
         """
         user_id = str(event.get_sender_id())
-        is_admin = user_id in self.admin_user_ids
+        is_admin = self._is_admin(event)
         
         # 管理员绕过冷却
         if is_admin and self.admin_bypass_cooldown:
@@ -277,7 +382,7 @@ class ComfyUIPlugin(Star):
         敏感词检查，返回 (是否通过, 触发的敏感词列表)
         """
         user_id = str(event.get_sender_id())
-        is_admin = user_id in self.admin_user_ids
+        is_admin = self._is_admin(event)
         
         sensitive = self._find_sensitive_words(prompt, event)
         
@@ -291,12 +396,25 @@ class ComfyUIPlugin(Star):
         
         return False, sensitive
 
+    # ====== 管理员判断（使用 AstrBot 系统管理员） ======
+    def _is_admin(self, event: AstrMessageEvent) -> bool:
+        """检查用户是否为 AstrBot 全局管理员，使用 AstrBot 内置管理员系统"""
+        try:
+            return event.is_admin()
+        except AttributeError:
+            return getattr(event, 'role', None) == 'admin'
+
     @filter.on_llm_request(priority=100)
     async def inject_system_prompt(self, event: AstrMessageEvent, req):
         """注入系统提示词 + 清理历史中的绘图提示词"""
         try:
-            llm_settings = self.config.get("llm_settings", {}) 
-            my_prompt = llm_settings.get("system_prompt", "")
+            # 优先从当前 persona 文件读取
+            my_prompt = self._get_current_persona_text()
+
+            # 如果 persona 为空，回退到配置中的 system_prompt（兼容旧方式）
+            if not my_prompt:
+                llm_settings = self.config.get("llm_settings", {})
+                my_prompt = llm_settings.get("system_prompt", "")
 
             if my_prompt:
                 current_prompt = getattr(req, "system_prompt", "") or ""
@@ -353,6 +471,124 @@ class ComfyUIPlugin(Star):
             conversation.history = json.dumps(history, ensure_ascii=False)
             logger.info(f"[ComfyUI] 🗑️ 已从 conversation.history 中清理 {cleaned} 条消息的绘图提示词")
 
+    def _get_current_persona_text(self) -> str:
+        """读取当前 persona 文件的文本内容"""
+        if self.current_persona:
+            persona_path = self.persona_dir / self.current_persona
+            if persona_path.exists():
+                try:
+                    return persona_path.read_text(encoding="utf-8").strip()
+                except Exception as e:
+                    logger.warning(f"[ComfyUI] 读取 persona 文件失败: {e}")
+        return ""
+
+    # ====== Profile 辅助方法 ======
+    def _load_profile_data(self, profile_name: str) -> dict:
+        """加载指定 profile 文件的配置数据"""
+        profile_path = self.profiles_dir / profile_name
+        if not profile_path.exists():
+            return {}
+        try:
+            with open(profile_path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception as e:
+            logger.error(f"[ComfyUI] 读取 Profile 失败 {profile_name}: {e}")
+            return {}
+
+    def _apply_current_profile(self) -> list:
+        """将当前 profile 的配置应用到各组件，返回应用结果列表"""
+        if not self.current_profile:
+            return []
+        data = self._load_profile_data(self.current_profile)
+        if not data:
+            return [f"⚠️ Profile 文件为空或读取失败: {self.current_profile}"]
+        return self._do_apply_profile(data)
+
+    def _do_apply_profile(self, data: dict) -> list:
+        """执行 profile 配置的应用"""
+        results = []
+
+        # 1. 切换工作流 + 节点 ID
+        wf = data.get("workflow", "")
+        if wf and self.api:
+            try:
+                exists, msg = self.api.reload_config(
+                    wf,
+                    input_id=data.get("input_node_id"),
+                    output_id=data.get("output_node_id"),
+                    neg_node_id=data.get("neg_node_id"),
+                )
+                results.append(f"{'✅' if exists else '⚠️'} 工作流: {wf} ({msg.split(chr(10))[0]})")
+            except Exception as e:
+                results.append(f"❌ 工作流切换失败: {e}")
+        elif wf:
+            results.append(f"⚠️ API未初始化，跳过工作流: {wf}")
+
+        # 2. 切换 Persona
+        persona = data.get("persona", "")
+        if persona:
+            persona_path = self.persona_dir / persona
+            if persona_path.exists():
+                self.current_persona = persona
+                try:
+                    self._persona_state_file.write_text(persona, encoding="utf-8")
+                except Exception:
+                    pass
+                results.append(f"✅ Persona: {persona}")
+            else:
+                results.append(f"⚠️ Persona 文件不存在: {persona}")
+
+        return results
+
+    def _save_profile_from_config(self, name: str):
+        """从当前 WebUI 配置保存为 Profile 文件（由 save_profile_name 字段触发）"""
+        if not name.endswith(".json"):
+            name += ".json"
+
+        wf_settings = self.config.get("workflow_settings", {})
+        data = {
+            "workflow": wf_settings.get("json_file", ""),
+            "input_node_id": str(wf_settings.get("input_node_id", "")),
+            "neg_node_id": str(wf_settings.get("neg_node_id", "")),
+            "output_node_id": str(wf_settings.get("output_node_id", "")),
+            "persona": self.config.get("llm_settings", {}).get("persona_file", ""),
+        }
+
+        save_path = self.profiles_dir / name
+        try:
+            with open(save_path, 'w', encoding='utf-8') as f:
+                json.dump(data, f, indent=4, ensure_ascii=False)
+            self._auto_update_schema()
+            logger.info(f"[ComfyUI] 📋 已从 WebUI 保存 Profile: {name}")
+        except Exception as e:
+            logger.error(f"[ComfyUI] ❌ 从 WebUI 保存 Profile 失败: {e}")
+            return
+
+        # 尝试清除 save_profile_name 字段
+        try:
+            if isinstance(self.config, AstrBotConfig):
+                self.config["profile_settings"]["save_profile_name"] = ""
+                self.config.save_config()
+                logger.info("[ComfyUI] 📋 save_profile_name 已自动清空")
+                return
+        except Exception:
+            pass
+
+        # 备用方案：直接写配置 JSON 文件
+        try:
+            config_dir = Path.cwd() / "data" / "config"
+            config_path = config_dir / "astrbot_plugin_comfyui_pro_config.json"
+            if config_path.exists():
+                with open(config_path, 'r', encoding='utf-8') as f:
+                    cfg = json.load(f)
+                if "profile_settings" in cfg:
+                    cfg["profile_settings"]["save_profile_name"] = ""
+                    with open(config_path, 'w', encoding='utf-8') as f:
+                        json.dump(cfg, f, indent=2, ensure_ascii=False)
+                    logger.info("[ComfyUI] 📋 save_profile_name 已通过配置文件清除")
+        except Exception as e:
+            logger.debug(f"[ComfyUI] 自动清除 save_profile_name 失败（非致命）: {e}")
+
     async def initialize(self):
         self.context.activate_llm_tool("comfyui_txt2img")
         logger.info("[ComfyUI] 🎨 插件初始化完成，LLM 工具已激活")
@@ -395,7 +631,7 @@ class ComfyUIPlugin(Star):
     async def cmd_probe_send(self, event: AstrMessageEvent):
         """探测 event.send() 是否会触发 on_decorating_result"""
         user_id = str(event.get_sender_id())
-        if user_id not in self.admin_user_ids:
+        if not self._is_admin(event):
             yield event.plain_result("🚫 仅管理员可用")
             return
 
@@ -422,7 +658,7 @@ class ComfyUIPlugin(Star):
         gid = self._get_group_id(event)
         policy = self._get_policy_for_event(event)
         user_id = str(event.get_sender_id())
-        is_admin = user_id in self.admin_user_ids
+        is_admin = self._is_admin(event)
         
         tips = [
             "🎨 ComfyUI Pro 插件帮助",
@@ -446,6 +682,11 @@ class ComfyUIPlugin(Star):
                 "  /comfy_save            导入新工作流",
                 "  /comfy_add             步数覆盖（按节点ID）",
                 "  /comfy_lock on|off     切换全局锁定",
+                "  /comfy_prompt_ls       列出 Persona 提示词",
+                "  /comfy_prompt_use <序号> 切换 Persona 提示词",
+                "  /comfy_profile_ls      列出配置档案",
+                "  /comfy_profile_use <序号> 一键应用配置档案",
+                "  /comfy_profile_save <名> 保存当前配置为档案",
                 "  /违禁级别              设置群敏感度",
                 ""
             ])
@@ -459,6 +700,8 @@ class ComfyUIPlugin(Star):
         if is_admin:
             tips.append(f"👑 身份：管理员")
             tips.append(f"📂 数据目录：{self.data_dir}")
+            tips.append(f"👤 当前 Persona：{self.current_persona or '无（使用配置默认值）'}")
+            tips.append(f"📋 当前 Profile：{self.current_profile or '无'}")
         
         yield event.plain_result("\n".join(tips))
     @filter.command("comfy_test_send2")
@@ -466,7 +709,7 @@ class ComfyUIPlugin(Star):
         """测试主动发送 - 第二轮"""
     
         user_id = str(event.get_sender_id())
-        if user_id not in self.admin_user_ids:
+        if not self._is_admin(event):
             yield event.plain_result("🚫 仅管理员可用")
             return
     
@@ -723,7 +966,7 @@ class ComfyUIPlugin(Star):
 
         # 检查管理员权限
         user_id = str(event.get_sender_id())
-        if user_id not in self.admin_user_ids:
+        if not self._is_admin(event):
             yield event.plain_result("🚫 权限不足，仅管理员可修改违禁级别")
             return
 
@@ -758,7 +1001,7 @@ class ComfyUIPlugin(Star):
     async def cmd_comfy_lock(self, event: AstrMessageEvent):
         """管理员动态切换全局锁定状态"""
         user_id = str(event.get_sender_id())
-        if user_id not in self.admin_user_ids:
+        if not self._is_admin(event):
             yield event.plain_result("🚫 权限不足，仅管理员可切换全局锁定")
             return
 
@@ -797,7 +1040,7 @@ class ComfyUIPlugin(Star):
     async def cmd_comfy_list(self, event: AstrMessageEvent):
         """列出当前所有可用工作流"""
         user_id = str(event.get_sender_id())
-        if user_id not in self.admin_user_ids:
+        if not self._is_admin(event):
             yield event.plain_result("🚫 权限不足，仅管理员可查看工作流列表")
             return
 
@@ -852,7 +1095,7 @@ class ComfyUIPlugin(Star):
     async def cmd_comfy_use(self, event: AstrMessageEvent):
         """切换工作流"""
         user_id = str(event.get_sender_id())
-        if user_id not in self.admin_user_ids:
+        if not self._is_admin(event):
             yield event.plain_result("🚫 权限不足，仅管理员可切换工作流")
             return
 
@@ -903,11 +1146,229 @@ class ComfyUIPlugin(Star):
         logger.info(f"[ComfyUI] 管理员 {user_id} 切换工作流: {filename}")
         yield event.plain_result(f"{status} {msg}")
 
+    # ====== Persona 管理 ======
+    @filter.command("comfy_prompt_ls")
+    async def cmd_comfy_prompt_list(self, event: AstrMessageEvent):
+        """列出所有可用 Persona 提示词文件"""
+        user_id = str(event.get_sender_id())
+        if not self._is_admin(event):
+            yield event.plain_result("🚫 权限不足，仅管理员可查看 Persona 列表")
+            return
+
+        if not self.persona_dir.exists():
+            yield event.plain_result("❌ Persona 目录不存在")
+            return
+
+        files = sorted([f.name for f in self.persona_dir.glob("*.txt")])
+
+        if not files:
+            yield event.plain_result("📂 目录中没有 Persona 文件\n请将 .txt 文件放入 persona 目录")
+            return
+
+        current = self.current_persona or "无（使用配置默认值）"
+
+        msg = ["📂 Persona 提示词列表", "━━━━━━━━━━━━━━━━━━"]
+
+        for i, f in enumerate(files, 1):
+            try:
+                content = (self.persona_dir / f).read_text(encoding="utf-8")
+                first_line = content.split('\n')[0][:50] or "(空文件)"
+            except Exception:
+                first_line = "(读取失败)"
+            marker = "✅" if f == self.current_persona else "  "
+            msg.append(f"{marker} {i}. {f}  —— {first_line}")
+
+        msg.append("")
+        msg.append("━━━━━━━━━━━━━━━━━━")
+        msg.append(f"📍 当前: {current}")
+        msg.append("切换：/comfy_prompt_use <序号>")
+
+        yield event.plain_result("\n".join(msg))
+
+    @filter.command("comfy_prompt_use")
+    async def cmd_comfy_prompt_use(self, event: AstrMessageEvent):
+        """切换 Persona 提示词文件"""
+        user_id = str(event.get_sender_id())
+        if not self._is_admin(event):
+            yield event.plain_result("🚫 权限不足，仅管理员可切换 Persona")
+            return
+
+        args = event.message_str.split()
+        if len(args) < 2:
+            yield event.plain_result(
+                "❌ 参数不足\n用法：/comfy_prompt_use <序号>"
+            )
+            return
+
+        files = sorted([f.name for f in self.persona_dir.glob("*.txt")])
+        if not files:
+            yield event.plain_result("📂 目录中没有 Persona 文件")
+            return
+
+        try:
+            index = int(args[1])
+            if not (1 <= index <= len(files)):
+                yield event.plain_result(f"❌ 序号错误，请输入 1 到 {len(files)} 之间的数字")
+                return
+            filename = files[index - 1]
+        except ValueError:
+            yield event.plain_result("❌ 请输入有效的数字序号")
+            return
+
+        # 持久化当前选择
+        try:
+            self._persona_state_file.write_text(filename, encoding="utf-8")
+        except Exception as e:
+            yield event.plain_result(f"❌ 保存状态失败: {e}")
+            return
+
+        self.current_persona = filename
+        logger.info(f"[ComfyUI] 管理员 {user_id} 切换 Persona: {filename}")
+        yield event.plain_result(
+            f"✅ 已切换 Persona 为：{filename}\n"
+            f"下次 LLM 请求时生效"
+        )
+
+    # ====== Profile 管理 ======
+    @filter.command("comfy_profile_ls")
+    async def cmd_comfy_profile_list(self, event: AstrMessageEvent):
+        """列出所有配置档案 (Profile)"""
+        user_id = str(event.get_sender_id())
+        if not self._is_admin(event):
+            yield event.plain_result("🚫 权限不足，仅管理员可查看 Profile 列表")
+            return
+
+        if not self.profiles_dir.exists():
+            yield event.plain_result("❌ Profile 目录不存在")
+            return
+
+        files = sorted([f.name for f in self.profiles_dir.glob("*.json")])
+
+        if not files:
+            yield event.plain_result("📂 目录中没有 Profile 文件\n请将 .json 文件放入 profiles 目录，或使用 /comfy_profile_save 创建")
+            return
+
+        current = self.current_profile or "无"
+
+        msg = ["📂 配置档案 (Profile) 列表", "━━━━━━━━━━━━━━━━━━"]
+
+        for i, f in enumerate(files, 1):
+            data = self._load_profile_data(f)
+            wf = data.get("workflow", "?")
+            persona = data.get("persona", "?")
+            in_id = data.get("input_node_id", "?")
+            marker = "✅" if f == self.current_profile else "  "
+            msg.append(f"{marker} {i}. {f}")
+            msg.append(f"     └ 工作流: {wf} | Pos:{in_id} | Neg:{data.get('neg_node_id','?')} | Out:{data.get('output_node_id','?') or '自动'} | Persona:{persona}")
+
+        msg.append("")
+        msg.append("━━━━━━━━━━━━━━━━━━")
+        msg.append(f"📍 当前: {current}")
+        msg.append("切换：/comfy_profile_use <序号>")
+        msg.append("保存当前配置为 Profile：/comfy_profile_save <名称>")
+
+        yield event.plain_result("\n".join(msg))
+
+    @filter.command("comfy_profile_use")
+    async def cmd_comfy_profile_use(self, event: AstrMessageEvent):
+        """一键切换配置档案（工作流+节点ID+Persona）"""
+        user_id = str(event.get_sender_id())
+        if not self._is_admin(event):
+            yield event.plain_result("🚫 权限不足，仅管理员可切换 Profile")
+            return
+
+        args = event.message_str.split()
+        if len(args) < 2:
+            yield event.plain_result(
+                "❌ 参数不足\n用法：/comfy_profile_use <序号>"
+            )
+            return
+
+        files = sorted([f.name for f in self.profiles_dir.glob("*.json")])
+        if not files:
+            yield event.plain_result("📂 目录中没有 Profile 文件")
+            return
+
+        try:
+            index = int(args[1])
+            if not (1 <= index <= len(files)):
+                yield event.plain_result(f"❌ 序号错误，请输入 1 到 {len(files)} 之间的数字")
+                return
+            filename = files[index - 1]
+        except ValueError:
+            yield event.plain_result("❌ 请输入有效的数字序号")
+            return
+
+        # 加载并应用 profile
+        data = self._load_profile_data(filename)
+        if not data:
+            yield event.plain_result(f"❌ 无法读取 Profile 文件: {filename}")
+            return
+
+        results = self._do_apply_profile(data)
+
+        # 持久化
+        try:
+            self._profile_state_file.write_text(filename, encoding="utf-8")
+        except Exception as e:
+            yield event.plain_result(f"❌ 保存状态失败: {e}")
+            return
+
+        self.current_profile = filename
+        logger.info(f"[ComfyUI] 📋 管理员 {user_id} 切换 Profile: {filename}")
+
+        msg = ["✅ 已应用配置档案\n", f"📋 Profile: {filename}", "━━━━━━━━━━━━━━━━━━"]
+        msg.extend(results)
+        yield event.plain_result("\n".join(msg))
+
+    @filter.command("comfy_profile_save")
+    async def cmd_comfy_profile_save(self, event: AstrMessageEvent):
+        """将当前配置（工作流+节点ID+Persona）保存为 Profile"""
+        user_id = str(event.get_sender_id())
+        if not self._is_admin(event):
+            yield event.plain_result("🚫 权限不足，仅管理员可保存 Profile")
+            return
+
+        args = event.message_str.split()
+        if len(args) < 2:
+            yield event.plain_result(
+                "❌ 参数不足\n用法：/comfy_profile_save <名称>\n示例：/comfy_profile_save 爱丽丝-3d"
+            )
+            return
+
+        name = args[1]
+        if not name.endswith(".json"):
+            name += ".json"
+
+        # 收集当前配置
+        wf = self.api.wf_filename if self.api else ""
+        data = {
+            "workflow": wf,
+            "input_node_id": self.api.input_id if self.api else "",
+            "neg_node_id": self.api.neg_node_id if self.api else "",
+            "output_node_id": self.api.output_id if self.api else "",
+            "persona": self.current_persona or "",
+        }
+
+        save_path = self.profiles_dir / name
+        try:
+            with open(save_path, 'w', encoding='utf-8') as f:
+                json.dump(data, f, indent=4, ensure_ascii=False)
+            self._auto_update_schema()
+            logger.info(f"[ComfyUI] 管理员 {user_id} 保存 Profile: {name}")
+            yield event.plain_result(
+                f"✅ 已保存配置档案: {name}\n"
+                f"工作流: {wf}\n"
+                f"Persona: {self.current_persona or '无'}"
+            )
+        except Exception as e:
+            yield event.plain_result(f"❌ 保存失败: {e}")
+
     @filter.command("comfy_save")
     async def cmd_comfy_save(self, event: AstrMessageEvent):
         """保存/导入工作流"""
         user_id = str(event.get_sender_id())
-        if user_id not in self.admin_user_ids:
+        if not self._is_admin(event):
             yield event.plain_result("🚫 权限不足，仅管理员可导入工作流")
             return
 
@@ -957,7 +1418,7 @@ class ComfyUIPlugin(Star):
     
         # 权限检查
         user_id = str(event.get_sender_id())
-        if user_id not in self.admin_user_ids:
+        if not self._is_admin(event):
             yield event.plain_result("🚫 权限不足，仅管理员可设置步数覆盖")
             return
     

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_comfyui_pro
-version: 2.3
-desc: AstrBot 的高级 ComfyUI 连接插件，支持多工作流热切换、LLM 智能绘图、自定义系统提示词及敏感词过滤。
+version: 2.4
+desc: AstrBot 的高级 ComfyUI 连接插件，支持多工作流热切换、LLM 智能绘图、Persona 提示词切换、Profile 一键配置及敏感词过滤。
 help: 安装后需在配置中填写 ComfyUI 地址。在聊天中发送 /comfy帮助 查看详细指令。
 author: lumingya
 repo: https://github.com/lumingya/astrbot_plugin_comfyui_pro

--- a/persona/default.txt
+++ b/persona/default.txt
@@ -1,0 +1,177 @@
+【角色扮演动态插图系统｜ComfyUI 分镜导演版】
+
+你正在参与角色扮演文本生成，同时兼任“动态插图分镜导演”。
+你的职责不是把正文逐句翻译成 prompt，而是从当前剧情里挑出“最值得定格的一瞬”，生成一条最稳定、最好看、最适合本地 ComfyUI 出图的 Stable Diffusion / Danbooru 风格英文 tags。
+
+你的最高目标只有 4 个：
+1. 单图单任务：一张图只服务一个视觉核心，不贪多。
+2. 稳定优先：宁可少画一点，也要镜头准、动作稳、脸不崩。
+3. 镜头优先：先决定拍什么、从哪拍，再写 tags。
+4. 角色连续：同一角色在同一段剧情中的外貌、服装、气质要保持一致，除非剧情明确改变。
+
+--------------------------------------------------
+【一、输出格式强约束｜违反即视为错误】
+--------------------------------------------------
+
+1. 唯一允许的图片触发标签：
+`<pic prompt="...">`
+
+系统检测到该标签后，会自动调用绘图接口并替换为图像预览。
+
+
+2. 每次插图时，必须严格按以下顺序输出：
+先输出：
+`<think> ... </think>`
+然后紧跟且只紧跟一个：
+`<pic prompt="...">`
+
+完成后再继续正文叙述。
+
+3. 若当前段落不值得插图：
+不要输出 `<think>`，也不要输出 `<pic>`，直接继续正文。
+
+4. `<pic>` 标签内部规则：
+- 只能有 `prompt` 一个属性
+- 内容必须是 Stable Diffusion / Danbooru 风格英文 tags
+- 只能使用英文单词或短语，半角逗号分隔
+- 允许使用小括号与权重，例如 `(profile view:1.2)`
+- 禁止自然语言长句
+- 禁止换行
+- 禁止非英语字符
+- 禁止在 `<pic>` 外输出“图片说明文字”
+
+5. `<render>` 协同规则：
+`<think>` 与 `<pic>` 可以直接写在 `<render template="novel"> ... </render>` 内部，不必拆块。
+正文与插图都保持在同一个 `<render>` 块中。
+
+6.系统会自动清除历史上下文中的`<pic prompt="...">`和`<think> ... </think>`标签，因此即便上下文中没有画图的记录，也不要以为不需要画图
+
+--------------------------------------------------
+【二、你的真正职责｜先当导演，再当写 tag 的人】
+--------------------------------------------------
+
+插图不是“把刚才那段话画出来”，而是：
+从当前剧情里找出最值得看的一个瞬间，
+选一个最合理的镜头，
+删掉所有会让画面变差的次要信息，
+然后把导演结论转成高收敛英文 tags。
+
+永远记住：
+- 不是信息越多越好，而是“第一眼就读得懂”最好
+- 不是词越花越好，而是“镜头和动作越明确”越好
+- 不是越像 C 站堆词越好，而是越像一个真正会拍画面的导演越好
+
+--------------------------------------------------
+【三、何时应该插图】
+--------------------------------------------------
+
+只有当以下任一条件成立时，才值得插图：
+
+1. 角色首次强势登场
+2. 情绪明显到达峰值
+3. 出现非常适合定格的动作瞬间
+4. 角色关系发生明显变化（靠近、对视、压制、保护、分离）
+5. 进入一个视觉价值很高的新场景
+6. 出现强烈的氛围画面（雨夜、窗边、天台、废墟、舞台等）
+7. 当前画面能显著增强代入感或观赏性
+
+以下情况通常不插图：
+- 纯说明
+- 过渡段
+- 普通对话推进
+- 没有清晰视觉核心的铺垫段
+- 信息很多但不适合定格的段落
+
+--------------------------------------------------
+【四、单图单任务｜先判定这张图的任务类型】
+--------------------------------------------------
+
+每次插图前，你必须先从以下任务类型中只选 1 个：
+
+1. 情绪图
+核心是表情、眼神、心理张力、氛围。
+默认镜头优先：
+`close up` / `portrait` / `upper body`
+`eye level`
+`three-quarter view` 或 `profile view`
+
+2. 动作图
+核心是动作几何、肢体张力、方向感、接触点。
+默认镜头优先：
+`upper body` 或 `cowboy shot`
+`from side` / `profile view` / `three-quarter view`
+`eye level` 或 `low angle`
+
+3. 登场图
+核心是角色魅力、身份感、服装、气场。
+默认镜头优先：
+`upper body` / `cowboy shot`
+`eye level` 或 `low angle`
+`centered`
+
+4. 关系图
+核心是两人之间的距离、对视、接触、支配感、保护感、暧昧感。
+默认镜头优先：
+`two shot`
+`upper body`
+`facing each other` / `side by side` / `over shoulder`
+
+5. 场景建立图
+核心是地点、时间、空间、氛围。
+默认镜头优先：
+`wide shot` / `establishing shot`
+人物降为构图元素，不强调面部与复杂动作。
+
+6. 魅力图
+核心是身体线条、姿态美感、观看体验、角色魅力。
+默认镜头优先：
+`three-quarter view` / `from side`
+`sitting` / `leaning` / `reclining` / `standing`
+`upper body` / `cowboy shot`
+
+7. 高光转折图
+核心是“这一幕最该被记住的瞬间”。
+优先保留最醒目的瞬间信息，舍弃冗余内容。
+
+--------------------------------------------------
+
+你可能会受到一系列参考提示词，当场景贴合时，主动复用参考提示词，那效果会比自己写更好。
+但需要注意场合，R18类型的提示词只有场景明确符合时才能主动生成。
+注意：
+1. 放弃“说人话”，拥抱“打标签” (Tagging > Sentences)
+不要给 AI 写小作文。不要写 A is doing B with C，而是拆解成独立的元素：
+
+❌ 错误：A girl is sitting on a boy's lap and a man's hand is touching her thigh.
+
+✅ 正确：1girl, 1boy, sitting on lap, (male hand touching female thigh:1.2).
+
+2. 肢体动作必须符合“几何逻辑”
+AI 没有三维骨骼概念，它是在二维平面上拼贴像素。给的动作越多，越容易翻车。
+
+如果你的核心是“温馨地坐在怀里”，就用 sitting on lap, arms around neck。
+
+如果你的核心是“腿搭在肩膀上”，那就不要写 sitting on lap，改为 mating press（非全年龄常见标签）或 lying on back, legs on shoulders。动作指令切忌“既要又要”。
+
+3. 镜头语言与画面内容要匹配
+如果你想要一个特写 (Close-up)，就不要去详细描述背景或角色的全身动作。
+
+画全身/半身： 描述姿势 (sitting on lap) + 动作 (arms around neck)。
+
+画特写： close-up, focus on thighs, (male hand touching female thigh:1.3), skindentation。把无关的全身动作（如 sitting on lap）删掉，让 AI 专心画腿和手。
+
+4. 精准使用高频“术语词”
+很多效果是不需要用长篇大论去描述的，一个专有标签就能搞定：
+
+表现肉感/勒肉：用 skindentation，而不是 smooth skin, shaping meat。
+
+表现视角：用 cowboy shot (七分身), from below (仰视), pov (第一人称视角)。
+
+这是例子：
+
+这是好的
+
+(white thighhighs:1.2), lace garter, (skindentation:1.2), 1girl，very long black hair,red eyes,1boy,sitting on lap, arms around neck, (touching thigh:1.1), trembling hands, (shaping thight:1.2),underwear,see through,foot foucus,white skirt,closed legs
+
+这是差的
+
+close-up, focus on thigh, (white thighhighs:1.2), lace garter, (skindentation:1.3), 1girl sitting on 1boy's lap, leg on shoulder, (man's hand touching thigh:1.1), trembling hands, smooth skin, masterpiece, soft lighting, (shaping thigh meat:1.2), high quality, detailed skin texture

--- a/profiles/default.json
+++ b/profiles/default.json
@@ -1,0 +1,7 @@
+{
+    "workflow": "workflow_api.json",
+    "input_node_id": "6",
+    "neg_node_id": "7",
+    "output_node_id": "",
+    "persona": "default.txt"
+}


### PR DESCRIPTION
当前分支实现了：
1. 将生图使用的提示词独立放置在./persona文件夹内，使用txt文本格式存储，实现了在插件配置页面的更换与在使用客户端（QQ等）的切换，同时尽可能保证兼容性。
2. 建立配置文件机制，将需要随工作流切换的正面提示词ID，负面提示词ID，图像输出ID，工作流文件与提示词文件统一绑定，支持插件配置页面的修改调整与使用端的配置文件切换。
3. 修改管理员实现路径，将原本的插件配置内管理员定义修改为与astrbot配置管理员身份文件统一，不需要在插件内设置管理员相关内容，插件会自动读取配置文件中管理员的身份ID，将以往只能在QQ中管理扩展到可以通过多平台管理，更易用。

尽管本人在本机内部已测试，测试结果良好，但需注意的是：该分支是使用Claude Code 通过DeepseekV4Pro修改，且本人不具备Python编程与插件设计修改的能力。因此，考虑到AI固有的黑箱问题，本人希望维护者谨慎查验，同时，本人也很难进行进一步的修改与调整，还请维护者原谅。